### PR TITLE
Add. Int64

### DIFF
--- a/Swift/utils.twig
+++ b/Swift/utils.twig
@@ -29,6 +29,8 @@ ImmutableMappable
 [{{ valueType.keysType.baseTypeName }}: {{ valueType.valuesType.baseTypeName }}]
 {%- elseif valueType.baseTypeName == "DateTime" -%}
 Date
+{%- elseif valueType.baseTypeName == "Long" -%}
+Int64
 {%- else -%}
 {{ valueType.baseTypeName }}
 {%- endif -%}


### PR DESCRIPTION
This PR closes issue of compile error using `Long` type in swift files.