### PR TITLE
add static versions of methods, add base method for override request

### DIFF
--- a/Swift/Methods.swift.twig
+++ b/Swift/Methods.swift.twig
@@ -2,10 +2,20 @@ import LeadKit
 import RxSwift
 import Alamofire
 
-extension NetworkService {
+{% set serviceName = concat(networkServiceName, "NetworkService") -%}
+
+extension {{ serviceName }} {
 
     {% for method in methods %}
-    {%- include 'blocks/method/method-func.twig' with { method: method } %}
+    {%- include 'blocks/method/method-func.twig' with { method: method, isStatic: false } %}
+
+    {% endfor %}
+}
+
+extension Singleton where Self: {{ serviceName }} {
+
+    {% for method in methods %}
+    {%- include 'blocks/method/method-func.twig' with { method: method, isStatic: true } %}
 
     {% endfor %}
 }

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -1,4 +1,5 @@
 import LeadKit
+import RxSwift
 
 {% set serviceName = concat(networkServiceName, "NetworkService") -%}
 class {{ serviceName }}: NetworkService, ConfigurableNetworkService {
@@ -9,6 +10,10 @@ class {{ serviceName }}: NetworkService, ConfigurableNetworkService {
 
     convenience init() {
         self.init(sessionManager: {{ serviceName }}.sessionManager)
+    }
+
+    func apiRequest<T: ImmutableMappable>(with parameters: ApiRequestParameters) -> Single<T> {
+        return rxRequest(with: parameters).map { $0.model }.asSingle()
     }
 
 }

--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -11,15 +11,21 @@
 {%- set funcName = utils.decapitalize(method.name) -%}
 
     /// {{ method.description }}
-    func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ "\n                   " }}{%- endif -%}
+    {{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ "\n                   " }}{%- endif -%}
                    encoding: ParameterEncoding = URLEncoding.default,
                    headers: HTTPHeaders? = nil) -> Single<{{ method.responseType.type.typeName }}> {
 
-        let parameters = ApiRequestParameters(url: "{{ method.url }}",
+        {% if isStatic -%}
+          return shared.{{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyParamName }},{{ "\n                   " }}{%- endif -%}
+                   encoding: encoding,
+                   headers: headers)
+        {%- else %}
+          let parameters = ApiRequestParameters(url: "{{ method.url }}",
                                               method: .{{ methodType }},
                                               parameters: {% if hasBody -%}{{ bodyParamName }}.toJSON(){%- else -%}nil{%- endif -%},
                                               encoding: encoding,
                                               headers: headers)
 
-        return rxRequest(with: parameters).map { $0.model }.asSingle()
+          return apiRequest(with: parameters)
+        {%- endif %}
     }


### PR DESCRIPTION
1] Теперь можно переопределись метод для запросов к апи
2] Можно вызывать методы апи без `shared`, если сабкласс имплементирует протокол Singleton
```swift
final class CustomBankNetworkService: BSPBAPINetworkService, Singleton {

    static let shared = CustomBankNetworkService()

    override static var baseUrl: String {
        return AppSettingsService.shared.authUrl
    }

    override func apiRequest<T: ImmutableMappable>(with parameters: ApiRequestParameters) -> Single<T> {
        return super.apiRequest(with: parameters)
            .on401Logout()
    }

}

CustomBankNetworkService.organizationGetRequest()
// the same as
CustomBankNetworkService.shared.organizationGetRequest()
```