### PR TITLE
update generation of NetworkService and methods

### DIFF
--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -2,14 +2,10 @@ import LeadKit
 import RxSwift
 
 {% set serviceName = concat(networkServiceName, "NetworkService") -%}
-class {{ serviceName }}: NetworkService, ConfigurableNetworkService {
-
-    class var baseUrl: String {
-        return "{{ apiUrl }}"
-    }
+class {{ serviceName }}: NetworkService {
 
     convenience init() {
-        self.init(sessionManager: {{ serviceName }}.sessionManager)
+        self.init(configuration: NetworkServiceConfiguration(baseUrl: "{{ apiUrl }}"))
     }
 
     func apiRequest<T: ImmutableMappable>(with parameters: ApiRequestParameters) -> Single<T> {

--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -12,16 +12,18 @@
 
     /// {{ method.description }}
     {{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ "\n                   " }}{%- endif -%}
+                   encoding: ParameterEncoding? = nil,
                    requestHeaders: HTTPHeaders? = nil) -> Single<{{ method.responseType.type.typeName }}> {
 
         {% if isStatic -%}
           return shared.{{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyParamName }},{{ "\n                   " }}{%- endif -%}
+                   encoding: encoding,
                    requestHeaders: requestHeaders)
         {%- else %}
           let parameters = ApiRequestParameters(url: configuration.baseUrl + "{{ method.url }}",
                                               method: .{{ methodType }},
                                               parameters: {% if hasBody -%}{{ bodyParamName }}.toJSON(){%- else -%}nil{%- endif -%},
-                                              encoding: configuration.encoding,
+                                              encoding: encoding ?? configuration.encoding,
                                               headers: requestHeaders)
 
           return apiRequest(with: parameters)

--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -12,19 +12,17 @@
 
     /// {{ method.description }}
     {{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ "\n                   " }}{%- endif -%}
-                   encoding: ParameterEncoding = URLEncoding.default,
-                   headers: HTTPHeaders? = nil) -> Single<{{ method.responseType.type.typeName }}> {
+                   requestHeaders: HTTPHeaders? = nil) -> Single<{{ method.responseType.type.typeName }}> {
 
         {% if isStatic -%}
           return shared.{{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyParamName }},{{ "\n                   " }}{%- endif -%}
-                   encoding: encoding,
-                   headers: headers)
+                   requestHeaders: requestHeaders)
         {%- else %}
-          let parameters = ApiRequestParameters(url: "{{ method.url }}",
+          let parameters = ApiRequestParameters(url: configuration.baseUrl + "{{ method.url }}",
                                               method: .{{ methodType }},
                                               parameters: {% if hasBody -%}{{ bodyParamName }}.toJSON(){%- else -%}nil{%- endif -%},
-                                              encoding: encoding,
-                                              headers: headers)
+                                              encoding: configuration.encoding,
+                                              headers: requestHeaders)
 
           return apiRequest(with: parameters)
         {%- endif %}


### PR DESCRIPTION
```swift
class BSPBAPINetworkService: NetworkService {

    convenience init() {
        self.init(configuration: NetworkServiceConfiguration(baseUrl: "http://bspb.ru"))
    }

    func apiRequest<T: ImmutableMappable>(with parameters: ApiRequestParameters) -> Single<T> {
        return rxRequest(with: parameters).map { $0.model }.asSingle()
    }

}
```

```swift
extension BSPBAPINetworkService {

    /// Получение списка организаций
    func organizationGetRequest(encoding: ParameterEncoding? = nil,
                   requestHeaders: HTTPHeaders? = nil) -> Single<OrganizationGetResponse> {

        
          let parameters = ApiRequestParameters(url: configuration.baseUrl + "organization/listing",
                                              method: .post,
                                              parameters: nil,
                                              encoding: encoding ?? configuration.encoding,
                                              headers: requestHeaders)

          return apiRequest(with: parameters)
    }

    /// Список доступных средств организации по валютам
    func organizationBalanceRequest(organizationItemGetBody: OrganizationItemGetBody,
                   encoding: ParameterEncoding? = nil,
                   requestHeaders: HTTPHeaders? = nil) -> Single<OrganizationBalanceResponse> {

        
          let parameters = ApiRequestParameters(url: configuration.baseUrl + "organization/available",
                                              method: .post,
                                              parameters: organizationItemGetBody.toJSON(),
                                              encoding: encoding ?? configuration.encoding,
                                              headers: requestHeaders)

          return apiRequest(with: parameters)
    }

    
}

extension Singleton where Self: BSPBAPINetworkService {

    /// Получение списка организаций
    static func organizationGetRequest(encoding: ParameterEncoding? = nil,
                   requestHeaders: HTTPHeaders? = nil) -> Single<OrganizationGetResponse> {

        return shared.organizationGetRequest(encoding: encoding,
                   requestHeaders: requestHeaders)
    }

    /// Список доступных средств организации по валютам
    static func organizationBalanceRequest(organizationItemGetBody: OrganizationItemGetBody,
                   encoding: ParameterEncoding? = nil,
                   requestHeaders: HTTPHeaders? = nil) -> Single<OrganizationBalanceResponse> {

        return shared.organizationBalanceRequest(organizationItemGetBody: organizationItemGetBody,
                   encoding: encoding,
                   requestHeaders: requestHeaders)
    }

    
}
```