### PR TITLE
Optional or nullable encoding fixed

### DIFF
--- a/Swift/macroses/common.utils.twig
+++ b/Swift/macroses/common.utils.twig
@@ -28,13 +28,17 @@
     {%- endif -%}
 {% endmacro %}
 
-{% macro formatEncodingValue(field) %}
+{% macro formatEncodingValue(field, strong) %}
     {%- import _self as self -%}
 
     {%- if field.type.type.baseTypeName == "DateTime" -%}
         {{- self.formatEncodingDate(field) -}}
     {%- elseif field.type.type.baseTypeName == "Decimal" -%}
-        {{ self.formatNullableOrOptional(field.name, field.nullable, field.optional) -}}
+        {%- if strong -%}
+            {{ field.name }}
+        {%- else -%}
+            {{ self.formatNullableOrOptional(field.name, field.nullable, field.optional) -}}
+        {%- endif -%}
         .decimalValue
     {%- else -%}
         {{ field.name }}
@@ -61,7 +65,7 @@
             try container.encode({{- self.formatEncodingDate(field) -}}, forKey: .{{- field.name -}})
         }
     {%- else -%}
-        try container.encodeIfPresent({{- self.formatEncodingValue(field) -}}, forKey: .{{- field.name -}})
+        try container.encodeIfPresent({{- self.formatEncodingValue(field, false) -}}, forKey: .{{- field.name -}})
     {%- endif -%}
 {% endmacro %}
 
@@ -72,12 +76,12 @@
         {{ self.encodeIfPresent(field) -}}
     {%- elseif field.nullable -%}
         if let {{ field.name }} = {{ field.name }} {
-            try container.encode({{- self.formatEncodingValue(field) -}}, forKey: .{{- field.name -}})
+            try container.encode({{- self.formatEncodingValue(field, true) -}}, forKey: .{{- field.name -}})
         } else {
             try container.encodeNil(forKey: .{{- field.name -}})
         }
     {%- else -%}
-        try container.encode({{- self.formatEncodingValue(field) -}}, forKey: .{{- field.name -}})
+        try container.encode({{- self.formatEncodingValue(field, false) -}}, forKey: .{{- field.name -}})
     {%- endif -%}
 {% endmacro %}
 


### PR DESCRIPTION
Было

```swift
if let limit = limit {
    try container.encode(limit?.decimalValue, forKey: .limit)
}

```

Стало

```swift
if let limit = limit {
    try container.encode(limit.decimalValue, forKey: .limit)
}
```