### PR TITLE
add copyWithout method to classes

### DIFF
--- a/Swift/Class.swift.twig
+++ b/Swift/Class.swift.twig
@@ -83,6 +83,10 @@ extension {{ type.baseTypeName }} {
         return {{ type.baseTypeName }}({%- include 'blocks/class/fields-optional-initialization.twig' with { fields: allFieldsOrdered } -%})
     }
 
+    func copy{%- if hasChilds -%}{{ type.baseTypeName }}{%- endif -%}Without({%- include 'blocks/class/bool-parameters-fields.twig' with { fields: allFieldsOrdered } -%}) -> {{ type.baseTypeName }} {
+        return {{ type.baseTypeName }}({%- include 'blocks/class/fields-without-initialization.twig' with { fields: allFieldsOrdered } -%})
+    }
+
 }
 {{ "\n" }}
 {%- endif -%}

--- a/Swift/blocks/class/bool-parameters-fields.twig
+++ b/Swift/blocks/class/bool-parameters-fields.twig
@@ -1,0 +1,7 @@
+{%- import '../../macroses/common.utils.twig' as utils -%}
+
+{%- if fields is not empty -%}
+{%- for field in fields -%}
+    {{ field.name }}: Bool = false{%- if not (loop.last) %}, {% endif %}
+{%- endfor -%}
+{%- endif -%}

--- a/Swift/blocks/class/fields-without-initialization.twig
+++ b/Swift/blocks/class/fields-without-initialization.twig
@@ -1,0 +1,7 @@
+{%- import '../../macroses/common.utils.twig' as utils -%}
+
+{%- if fields is not empty -%}
+{%- for field in fields -%}
+    {{ field.name }}: {{ field.name }} ? {{ utils.defaultValueForField(field) }} : self.{{ field.name }}{%- if not (loop.last) %}, {% endif %}
+{%- endfor -%}
+{%- endif -%}


### PR DESCRIPTION
Добавлен метод `copyWithout` в extension ко всем генерируемым моделям: 
```swift
extension CardInfoChangeBody {

    static let newCardInfoChangeBody = CardInfoChangeBody(email: nil, cardId: "", sessionId: "")

    func copyWith(email: String? = nil, cardId: String? = nil, sessionId: String? = nil) -> CardInfoChangeBody {
        return CardInfoChangeBody(email: email ?? self.email, cardId: cardId ?? self.cardId, sessionId: sessionId ?? self.sessionId)
    }

    func copyWithout(email: Bool = false, cardId: Bool = false, sessionId: Bool = false) -> CardInfoChangeBody {
        return CardInfoChangeBody(email: email ? nil : self.email, cardId: cardId ? "" : self.cardId, sessionId: sessionId ? "" : self.sessionId)
    }

}
```

Работает аналогично `copyWith`, только наоборот:

<img width="616" alt="screenshot 2018-10-30 at 15 55 43" src="https://user-images.githubusercontent.com/6436245/47719487-638bac00-dc5c-11e8-95d6-1bd8ad7f0a14.png">