### PR TITLE
use Swift 4.2 CaseIterable. escape "operator" keyword

### DIFF
--- a/Swift/Enum.swift.twig
+++ b/Swift/Enum.swift.twig
@@ -8,9 +8,7 @@ import Foundation
 {% for value in values -%}
 /// - {{ utils.decapitalize(value.name) }}: {{ value.description }}
 {% endfor -%}
-enum {{ name }}: {{ enumutils.enumType(valuesTypes) }}, Codable, RawRepresentable {
-  
-    {% include 'blocks/enum/all-items.twig' %}
+enum {{ name }}: {{ enumutils.enumType(valuesTypes) }}, Codable, RawRepresentable, CaseIterable {
     {% include 'blocks/enum/cases.twig' with { values: values } %}
 
 }

--- a/Swift/blocks/enum/all-items.twig
+++ b/Swift/blocks/enum/all-items.twig
@@ -1,8 +1,0 @@
-{% import '../../macroses/common.utils.twig' as utils -%}
-static var allItems: [{{ name }}] {
-    {{ "    " }}return [
-    {%- for value in values -%}
-        .{{ utils.decapitalize(value.name) }}{%- if not (loop.last) -%}, {% endif -%}
-    {%- endfor -%}
-    ]
-{{ "    " }}}

--- a/Swift/macroses/common.utils.twig
+++ b/Swift/macroses/common.utils.twig
@@ -50,7 +50,7 @@
 {%- endmacro -%}
 
 {% macro escapeIfNeeded(expr) %}
-    {%- if expr == "default" -%}
+    {%- if expr == "default" or expr == "operator" -%}
         `{{ expr }}`
     {%- else -%}
         {{ expr }}


### PR DESCRIPTION
Old:
```swift
enum RatingTag: String, Codable, RawRepresentable {
  
    static var allItems: [RatingTag] {
        return [.operator, .place, .generalState, .refueller]
    }

    
    case operator // compiler error
    case place
    case generalState
    case refueller

}
```
New:
```swift
enum RatingTag: String, Codable, RawRepresentable, CaseIterable {
    
    case `operator`
    case place
    case generalState
    case refueller

}
```