### PR TITLE
Feature/network protocol

### DIFF
--- a/Swift/Methods.swift.twig
+++ b/Swift/Methods.swift.twig
@@ -16,7 +16,7 @@ extension Singleton where Self: {{ protocolName }} {
 
     {% for method in methods %}
     {%- include 'blocks/method/method-func.twig' with { method: method, isStatic: true } %}
-
+    
     {% endfor %}
 }
 {{ "\n" }}

--- a/Swift/Methods.swift.twig
+++ b/Swift/Methods.swift.twig
@@ -2,9 +2,9 @@ import LeadKit
 import RxSwift
 import Alamofire
 
-{% set serviceName = concat(networkServiceName, "NetworkService") -%}
+{% set protocolName = concat(networkServiceName, "NetworkProtocol") -%}
 
-extension {{ serviceName }} {
+extension {{ protocolName }} {
 
     {% for method in methods %}
     {%- include 'blocks/method/method-func.twig' with { method: method, isStatic: false } %}
@@ -12,7 +12,7 @@ extension {{ serviceName }} {
     {% endfor %}
 }
 
-extension Singleton where Self: {{ serviceName }} {
+extension Singleton where Self: {{ protocolName }} {
 
     {% for method in methods %}
     {%- include 'blocks/method/method-func.twig' with { method: method, isStatic: true } %}

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -11,10 +11,10 @@ protocol {{ protocolName }} {
 
     func apiRequest<T: Decodable>(with parameters: ApiRequestParameters, decoder: JSONDecoder) -> Single<T>
     func apiRequestParameters(relativeUrl: String,
-                              method: HTTPMethod = .get,
-                              parameters: Parameters? = nil,
-                              requestEncoding: ParameterEncoding? = nil,
-                              requestHeaders: HTTPHeaders? = nil) -> ApiRequestParameters
+                              method: HTTPMethod,
+                              parameters: Parameters?
+                              requestEncoding: ParameterEncoding?,
+                              requestHeaders: HTTPHeaders?) -> ApiRequestParameters
 
     {% for method in methods %}
     {{ isStatic ? "static " : "" }}func {{ methodUtils.funcName }}({%- if methodUtils.hasBody -%}{{ methodUtils.bodyParamName }}: {{ methodUtils.bodyTypeName }},{{ "\n                   " }}{%- endif -%}

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -1,5 +1,3 @@
-{%- import "blocks/method/method-func.twig" as methodUtils -%}
-
 import LeadKit
 import RxSwift
 import Alamofire
@@ -16,10 +14,8 @@ protocol {{ protocolName }} {
                               requestEncoding: ParameterEncoding?,
                               requestHeaders: HTTPHeaders?) -> ApiRequestParameters
 
-    {% for method in methodUtils.methods %}
-    {{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ "\n                   " }}{%- endif -%}
-                   requestEncoding: ParameterEncoding? = nil,
-                   requestHeaders: HTTPHeaders? = nil) -> Single<{{ method.responseType.type.typeName }}>
+    {% for method in methods %}
+    {%- include 'blocks/method/method-declaration.twig' with { method: method, isStatic: false } %}
     {% endfor %}
 }
 

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -15,7 +15,7 @@ protocol {{ protocolName }} {
                               requestHeaders: HTTPHeaders?) -> ApiRequestParameters
 
     {% for method in methods %}
-    {%- include 'blocks/method/method-declaration.twig' with { method: method, isStatic: false } %}
+    {%- include 'blocks/method/method-declaration.twig' with { method: method, isStatic: false } -%}
     {% endfor %}
 }
 

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -2,8 +2,6 @@ import LeadKit
 import RxSwift
 import Alamofire
 
-{% import "Methods.swift.twig" as Methods %}
-
 {% set serviceName = concat(networkServiceName, "NetworkService") -%}
 {% set protocolName = concat(networkServiceName, "NetworkProtocol") -%}
 
@@ -16,7 +14,7 @@ protocol {{ protocolName }} {
                               requestEncoding: ParameterEncoding?,
                               requestHeaders: HTTPHeaders?) -> ApiRequestParameters
 
-    {% for method in Methods.methods %}
+    {% for method in methods %}
     {%- include 'blocks/method/method-declaration.twig' with { method: method, isStatic: false } %}
     {% endfor %}
 }

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -2,6 +2,8 @@ import LeadKit
 import RxSwift
 import Alamofire
 
+{% import "Methods.swift.twig" as Methods %}
+
 {% set serviceName = concat(networkServiceName, "NetworkService") -%}
 {% set protocolName = concat(networkServiceName, "NetworkProtocol") -%}
 
@@ -14,7 +16,7 @@ protocol {{ protocolName }} {
                               requestEncoding: ParameterEncoding?,
                               requestHeaders: HTTPHeaders?) -> ApiRequestParameters
 
-    {% for method in methods %}
+    {% for method in Methods.methods %}
     {%- include 'blocks/method/method-declaration.twig' with { method: method, isStatic: false } %}
     {% endfor %}
 }

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -1,9 +1,29 @@
+{%- import "blocks/method/method-func.twig" as methodUtils -%}
+
 import LeadKit
 import RxSwift
 import Alamofire
 
 {% set serviceName = concat(networkServiceName, "NetworkService") -%}
-class {{ serviceName }}: NetworkService {
+{% set protocolName = concat(networkServiceName, "NetworkProtocol") -%}
+
+protocol {{ protocolName }} {
+
+    func apiRequest<T: Decodable>(with parameters: ApiRequestParameters, decoder: JSONDecoder) -> Single<T>
+    func apiRequestParameters(relativeUrl: String,
+                              method: HTTPMethod = .get,
+                              parameters: Parameters? = nil,
+                              requestEncoding: ParameterEncoding? = nil,
+                              requestHeaders: HTTPHeaders? = nil) -> ApiRequestParameters
+
+    {% for method in methods %}
+    {{ isStatic ? "static " : "" }}func {{ methodUtils.funcName }}({%- if methodUtils.hasBody -%}{{ methodUtils.bodyParamName }}: {{ methodUtils.bodyTypeName }},{{ "\n                   " }}{%- endif -%}
+                   requestEncoding: ParameterEncoding? = nil,
+                   requestHeaders: HTTPHeaders? = nil) -> Single<{{ method.responseType.type.typeName }}>
+    {% endfor %}
+}
+
+class {{ serviceName }}: NetworkService, {{ protocolName }} {
 
     static let apiBaseUrl = "{{ apiUrl }}"
 

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -12,12 +12,12 @@ protocol {{ protocolName }} {
     func apiRequest<T: Decodable>(with parameters: ApiRequestParameters, decoder: JSONDecoder) -> Single<T>
     func apiRequestParameters(relativeUrl: String,
                               method: HTTPMethod,
-                              parameters: Parameters?
+                              parameters: Parameters?,
                               requestEncoding: ParameterEncoding?,
                               requestHeaders: HTTPHeaders?) -> ApiRequestParameters
 
-    {% for method in methods %}
-    {{ isStatic ? "static " : "" }}func {{ methodUtils.funcName }}({%- if methodUtils.hasBody -%}{{ methodUtils.bodyParamName }}: {{ methodUtils.bodyTypeName }},{{ "\n                   " }}{%- endif -%}
+    {% for method in methodUtils.methods %}
+    {{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ "\n                   " }}{%- endif -%}
                    requestEncoding: ParameterEncoding? = nil,
                    requestHeaders: HTTPHeaders? = nil) -> Single<{{ method.responseType.type.typeName }}>
     {% endfor %}

--- a/Swift/blocks/method/method-declaration.twig
+++ b/Swift/blocks/method/method-declaration.twig
@@ -1,0 +1,12 @@
+{%- import '../../macroses/common.utils.twig' as utils -%}
+
+{%- if (method.bodyType is not null) -%}
+  {%- set bodyParamName = utils.decapitalize(method.bodyType.type.typeName) -%}
+  {%- set bodyTypeName = method.bodyType.type.typeName -%}
+
+  {%- set hasBody = true -%}
+{%- endif -%}
+
+{%- set funcName = utils.decapitalize(method.name) -%}
+
+{{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ " " }}{%- endif -%}requestEncoding: ParameterEncoding?, requestHeaders: HTTPHeaders?) -> Single<{{ method.responseType.type.typeName }}>

--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -26,6 +26,6 @@
                                               requestEncoding: requestEncoding,
                                               requestHeaders: requestHeaders)
 
-          return apiRequest(with: parameters)
+          return apiRequest(with: parameters, decoder: JSONDecoder())
         {%- endif %}
     }


### PR DESCRIPTION
Generated Network service now conforms to the protocol on which extensions all the methods are generated.

```swift
class BSPBAPINetworkService: NetworkService, BSPBAPINetworkProtocol
```

```swift
extension Singleton where Self: BSPBAPINetworkProtocol
```

Protocol contains:
```swift
protocol BSPBAPINetworkProtocol {

    func apiRequest<T: Decodable>(with parameters: ApiRequestParameters, decoder: JSONDecoder) -> Single<T>
    func apiRequestParameters(relativeUrl: String,
                              method: HTTPMethod,
                              parameters: Parameters?,
                              requestEncoding: ParameterEncoding?,
                              requestHeaders: HTTPHeaders?) -> ApiRequestParameters
}
```

and declarations of all generated methods