### PR TITLE
Network service lazy request generation

### DIFF
--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -20,12 +20,15 @@
                    requestEncoding: requestEncoding,
                    requestHeaders: requestHeaders)
         {%- else -%}
-          let parameters = apiRequestParameters(relativeUrl: "{{ method.url }}",
+          return .deferred {
+            let parameters = self.apiRequestParameters(relativeUrl: "{{ method.url }}",
                                               method: .{{ methodType }},
                                               parameters: {% if hasBody -%}{{ bodyParamName }}.toJSON(){%- else -%}nil{%- endif -%},
                                               requestEncoding: requestEncoding,
                                               requestHeaders: requestHeaders)
 
-          return apiRequest(with: parameters, decoder: JSONDecoder())
+            return self.apiRequest(with: parameters, decoder: JSONDecoder())
+          }
+          
         {%- endif %}
     }


### PR DESCRIPTION
Network service now create lazy requests, which do all working stuff only on subscription.

```swift
func orderCreateRequest(orderCreateBody: OrderCreateBody,
                   requestEncoding: ParameterEncoding? = nil,
                   requestHeaders: HTTPHeaders? = nil) -> Single<OrderCreateRequestResponse> {

        return .deferred {
            let parameters = self.apiRequestParameters(relativeUrl: "/payments/order/create",
                                              method: .post,
                                              parameters: orderCreateBody.toJSON(),
                                              requestEncoding: requestEncoding,
                                              requestHeaders: requestHeaders)

            return self.apiRequest(with: parameters, decoder: JSONDecoder())
        }
    }

```