### PR TITLE
Feature/deferred api parameters

### DIFF
--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -28,8 +28,8 @@ class {{ serviceName }}: NetworkService, {{ protocolName }} {
     }
 
     func apiRequest<T: Decodable>(with parameters: Single<ApiRequestParameters>, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
-        return parameters.flatMap { parameters -> Single<T> in
-            self.rxRequest(with: parameters, decoder: decoder).map { $0.model }.asSingle()
+        return parameters.flatMap {
+            self.rxRequest(with: $0, decoder: decoder).map { $0.model }.asSingle()
         }
     }
 

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -27,8 +27,8 @@ class {{ serviceName }}: NetworkService, {{ protocolName }} {
         self.init(configuration: NetworkServiceConfiguration(baseUrl: {{ serviceName }}.apiBaseUrl))
     }
 
-    func apiRequest<T: Decodable>(with parameters: Single<ApiRequestParameters>, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
-        return parameters.flatMap {
+    func apiRequest<T: Decodable>(with parametersSingle: Single<ApiRequestParameters>, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
+        return parametersSingle.flatMap {
             self.rxRequest(with: $0, decoder: decoder).map { $0.model }.asSingle()
         }
     }

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -7,7 +7,7 @@ import Alamofire
 
 protocol {{ protocolName }} {
 
-    func apiRequest<T: Decodable>(with parameters: Single<ApiRequestParameters>, decoder: JSONDecoder) -> Single<T>
+    func apiRequest<T: Decodable>(with parametersSingle: Single<ApiRequestParameters>, decoder: JSONDecoder) -> Single<T>
     func deferredApiRequestParameters(relativeUrl: String,
                               method: HTTPMethod,
                               parameters: Parameters?,

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -28,7 +28,9 @@ class {{ serviceName }}: NetworkService, {{ protocolName }} {
     }
 
     func apiRequest<T: Decodable>(with parameters: Single<ApiRequestParameters>, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
-        return rxRequest(with: parameters, decoder: decoder).map { $0.model }.asSingle()
+        return parameters.flatMap { parameters -> Single<T> in
+            self.rxRequest(with: parameters, decoder: decoder).map { $0.model }.asSingle()
+        }
     }
 
     func deferredApiRequestParameters(relativeUrl: String,
@@ -36,11 +38,17 @@ class {{ serviceName }}: NetworkService, {{ protocolName }} {
                               parameters: Parameters? = nil,
                               requestEncoding: ParameterEncoding? = nil,
                               requestHeaders: HTTPHeaders? = nil) -> Single<ApiRequestParameters> {
-        return configuration.apiRequestParameters(relativeUrl: relativeUrl,
-                                                  method: method,
-                                                  parameters: parameters,
-                                                  requestEncoding: requestEncoding,
-                                                  requestHeaders: requestHeaders)
+        return .deferred({ () -> Single<ApiRequestParameters> in
+            return .create(subscribe: { single -> Disposable in
+                let parameters = self.configuration.apiRequestParameters(relativeUrl: relativeUrl,
+                                                                    method: method,
+                                                                    parameters: parameters,
+                                                                    requestEncoding: requestEncoding,
+                                                                    requestHeaders: requestHeaders)
+                single(.success(parameters))
+                return Disposables.create()
+            })
+        })
     }
 
 }

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -7,12 +7,12 @@ import Alamofire
 
 protocol {{ protocolName }} {
 
-    func apiRequest<T: Decodable>(with parameters: ApiRequestParameters, decoder: JSONDecoder) -> Single<T>
-    func apiRequestParameters(relativeUrl: String,
+    func apiRequest<T: Decodable>(with parameters: Single<ApiRequestParameters>, decoder: JSONDecoder) -> Single<T>
+    func deferredApiRequestParameters(relativeUrl: String,
                               method: HTTPMethod,
                               parameters: Parameters?,
                               requestEncoding: ParameterEncoding?,
-                              requestHeaders: HTTPHeaders?) -> ApiRequestParameters
+                              requestHeaders: HTTPHeaders?) -> Single<ApiRequestParameters>
 
     {% for method in methods %}
     {%- include 'blocks/method/method-declaration.twig' with { method: method, isStatic: false } -%}
@@ -27,15 +27,15 @@ class {{ serviceName }}: NetworkService, {{ protocolName }} {
         self.init(configuration: NetworkServiceConfiguration(baseUrl: {{ serviceName }}.apiBaseUrl))
     }
 
-    func apiRequest<T: Decodable>(with parameters: ApiRequestParameters, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
+    func apiRequest<T: Decodable>(with parameters: Single<ApiRequestParameters>, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
         return rxRequest(with: parameters, decoder: decoder).map { $0.model }.asSingle()
     }
 
-    func apiRequestParameters(relativeUrl: String,
+    func deferredApiRequestParameters(relativeUrl: String,
                               method: HTTPMethod = .get,
                               parameters: Parameters? = nil,
                               requestEncoding: ParameterEncoding? = nil,
-                              requestHeaders: HTTPHeaders? = nil) -> ApiRequestParameters {
+                              requestHeaders: HTTPHeaders? = nil) -> Single<ApiRequestParameters> {
         return configuration.apiRequestParameters(relativeUrl: relativeUrl,
                                                   method: method,
                                                   parameters: parameters,

--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -34,22 +34,17 @@ class {{ serviceName }}: NetworkService, {{ protocolName }} {
     }
 
     func deferredApiRequestParameters(relativeUrl: String,
-                              method: HTTPMethod = .get,
-                              parameters: Parameters? = nil,
-                              requestEncoding: ParameterEncoding? = nil,
-                              requestHeaders: HTTPHeaders? = nil) -> Single<ApiRequestParameters> {
-        return .deferred({ () -> Single<ApiRequestParameters> in
-            return .create(subscribe: { single -> Disposable in
-                let parameters = self.configuration.apiRequestParameters(relativeUrl: relativeUrl,
-                                                                    method: method,
-                                                                    parameters: parameters,
-                                                                    requestEncoding: requestEncoding,
-                                                                    requestHeaders: requestHeaders)
-                single(.success(parameters))
-                return Disposables.create()
-            })
-        })
+                                      method: HTTPMethod = .get,
+                                      parameters: Parameters? = nil,
+                                      requestEncoding: ParameterEncoding? = nil,
+                                      requestHeaders: HTTPHeaders? = nil) -> Single<ApiRequestParameters> {
+        return .deferredJust {
+            self.configuration.apiRequestParameters(relativeUrl: relativeUrl,
+                                                    method: method,
+                                                    parameters: parameters,
+                                                    requestEncoding: requestEncoding,
+                                                    requestHeaders: requestHeaders)
+        }
     }
-
 }
 {{ "\n" }}

--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -20,13 +20,13 @@
                    requestEncoding: requestEncoding,
                    requestHeaders: requestHeaders)
         {%- else -%}
-          let parameters = self.apiRequestParameters(relativeUrl: "{{ method.url }}",
+          let parameters = deferredApiRequestParameters(relativeUrl: "{{ method.url }}",
                                               method: .{{ methodType }},
                                               parameters: {% if hasBody -%}{{ bodyParamName }}.toJSON(){%- else -%}nil{%- endif -%},
                                               requestEncoding: requestEncoding,
                                               requestHeaders: requestHeaders)
 
-          return self.apiRequest(with: parameters, decoder: JSONDecoder())
+          return apiRequest(with: parameters, decoder: JSONDecoder())
           
         {%- endif %}
     }

--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -20,15 +20,13 @@
                    requestEncoding: requestEncoding,
                    requestHeaders: requestHeaders)
         {%- else -%}
-          return .deferred {
-            let parameters = self.apiRequestParameters(relativeUrl: "{{ method.url }}",
+          let parameters = self.apiRequestParameters(relativeUrl: "{{ method.url }}",
                                               method: .{{ methodType }},
                                               parameters: {% if hasBody -%}{{ bodyParamName }}.toJSON(){%- else -%}nil{%- endif -%},
                                               requestEncoding: requestEncoding,
                                               requestHeaders: requestHeaders)
 
-            return self.apiRequest(with: parameters, decoder: JSONDecoder())
-          }
+          return self.apiRequest(with: parameters, decoder: JSONDecoder())
           
         {%- endif %}
     }


### PR DESCRIPTION
Old:
Функция `cancelOrder` приведена в качестве примера. В проекте есть и другие методы, но они генерируются из одного шаблона.
```swift
func cancelOrder(orderCancelBody: OrderCancelBody,
                     requestEncoding: ParameterEncoding? = nil,
                     requestHeaders: HTTPHeaders? = nil) -> Single<ResponseCancelOrderBodyResult> {
        
        return .deferred {
            let parameters = deferredApiRequestParameters(relativeUrl: "/v1.1/MobCloseEncashmentRequest",
                                                          method: .post,
                                                          parameters: orderCancelBody.toJSON(),
                                                          requestEncoding: requestEncoding,
                                                          requestHeaders: requestHeaders)
            
            return self.apiRequest(with: parameters, decoder: JSONDecoder())
        }
}

func apiRequest<T: Decodable>(with parameters: ApiRequestParameters, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
        return rxRequest(with: parameters, decoder: decoder).map { $0.model }.asSingle()
}

func apiRequestParameters(relativeUrl: String,
                              method: HTTPMethod = .get,
                              parameters: Parameters? = nil,
                              requestEncoding: ParameterEncoding? = nil,
                              requestHeaders: HTTPHeaders? = nil) ->ApiRequestParameters {
        return configuration.apiRequestParameters(relativeUrl: relativeUrl,
                                                  method: method,
                                                  parameters: parameters,
                                                  requestEncoding: requestEncoding,
                                                  requestHeaders: requestHeaders)
    }
```

New:
```swift
func cancelOrder(orderCancelBody: OrderCancelBody,
                     requestEncoding: ParameterEncoding? = nil,
                     requestHeaders: HTTPHeaders? = nil) -> Single<ResponseCancelOrderBodyResult> {
        
        let parameters = deferredApiRequestParameters(relativeUrl: "/v1.1/MobCloseEncashmentRequest",
                                                      method: .post,
                                                      parameters: orderCancelBody.toJSON(),
                                                      requestEncoding: requestEncoding,
                                                      requestHeaders: requestHeaders)
        
        return apiRequest(with: parameters, decoder: JSONDecoder())
}

func apiRequest<T: Decodable>(with parametersSingle: Single<ApiRequestParameters>, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
        return parametersSingle.flatMap {
            self.rxRequest(with: $0, decoder: decoder).map { $0.model }.asSingle()
        }
}

func deferredApiRequestParameters(relativeUrl: String,
                              method: HTTPMethod = .get,
                              parameters: Parameters? = nil,
                              requestEncoding: ParameterEncoding? = nil,
                              requestHeaders: HTTPHeaders? = nil) -> Single<ApiRequestParameters> {
        return .deferredJust {
            self.configuration.apiRequestParameters(relativeUrl: relativeUrl,
                                                    method: method,
                                                    parameters: parameters,
                                                    requestEncoding: requestEncoding,
                                                    requestHeaders: requestHeaders)
        }
    }
```