### PR TITLE
Added additional valid status codes parameter to request methods

### DIFF
--- a/Swift/NetworkService.swift.twig
+++ b/Swift/NetworkService.swift.twig
@@ -7,7 +7,7 @@ import Alamofire
 
 protocol {{ protocolName }} {
 
-    func apiRequest<T: Decodable>(with parametersSingle: Single<ApiRequestParameters>, decoder: JSONDecoder) -> Single<T>
+    func apiRequest<T: Decodable>(with parametersSingle: Single<ApiRequestParameters>, additionalValidStatusCodes: Set<Int>, decoder: JSONDecoder) -> Single<T>
     func deferredApiRequestParameters(relativeUrl: String,
                               method: HTTPMethod,
                               parameters: Parameters?,
@@ -27,9 +27,9 @@ class {{ serviceName }}: NetworkService, {{ protocolName }} {
         self.init(configuration: NetworkServiceConfiguration(baseUrl: {{ serviceName }}.apiBaseUrl))
     }
 
-    func apiRequest<T: Decodable>(with parametersSingle: Single<ApiRequestParameters>, decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
+    func apiRequest<T: Decodable>(with parametersSingle: Single<ApiRequestParameters>, additionalValidStatusCodes: Set<Int> = [], decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
         return parametersSingle.flatMap {
-            self.rxRequest(with: $0, decoder: decoder).map { $0.model }.asSingle()
+            self.rxRequest(with: $0, additionalValidStatusCodes: additionalValidStatusCodes, decoder: decoder).map { $0.model }.asSingle()
         }
     }
 

--- a/Swift/blocks/method/method-declaration.twig
+++ b/Swift/blocks/method/method-declaration.twig
@@ -9,4 +9,4 @@
 
 {%- set funcName = utils.decapitalize(method.name) -%}
 
-{{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ " " }}{%- endif -%}requestEncoding: ParameterEncoding?, requestHeaders: HTTPHeaders?) -> Single<{{ method.responseType.type.typeName }}>
+{{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ " " }}{%- endif -%}requestEncoding: ParameterEncoding?, requestHeaders: HTTPHeaders?, additionalValidStatusCodes: Set<Int>) -> Single<{{ method.responseType.type.typeName }}>

--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -13,7 +13,8 @@
     /// {{ method.description }}
     {{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ "\n                   " }}{%- endif -%}
                    requestEncoding: ParameterEncoding? = nil,
-                   requestHeaders: HTTPHeaders? = nil) -> Single<{{ method.responseType.type.typeName }}> {
+                   requestHeaders: HTTPHeaders? = nil,
+                   additionalValidStatusCodes: Set<Int> = []) -> Single<{{ method.responseType.type.typeName }}> {
 
         {% if isStatic -%}
           return shared.{{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyParamName }},{{ "\n                   " }}{%- endif -%}
@@ -26,7 +27,7 @@
                                               requestEncoding: requestEncoding,
                                               requestHeaders: requestHeaders)
 
-          return apiRequest(with: parameters, decoder: JSONDecoder())
+          return apiRequest(with: parameters, additionalValidStatusCodes: additionalValidStatusCodes, decoder: JSONDecoder())
           
         {%- endif %}
     }


### PR DESCRIPTION
**Before:**
```swift
func userRegisterRequest(userRegisterBody: UserRegisterBody,
               requestEncoding: ParameterEncoding? = nil,
               requestHeaders: HTTPHeaders? = nil) -> Single<UserRegisterRequestResponse> {

    let parameters = deferredApiRequestParameters(relativeUrl: "/user/register",
                                              method: .post,
                                              parameters: userRegisterBody.toJSON(),
                                              requestEncoding: requestEncoding,
                                              requestHeaders: requestHeaders)

      return apiRequest(with: parameters, decoder: JSONDecoder())
}

```
**After:**
```swift
func userRegisterRequest(userRegisterBody: UserRegisterBody,
                   requestEncoding: ParameterEncoding? = nil,
                   requestHeaders: HTTPHeaders? = nil,
                   additionalValidStatusCodes: Set<Int> = []) -> Single<UserRegisterRequestResponse> {

    let parameters = deferredApiRequestParameters(relativeUrl: "/user/register",
                                              method: .post,
                                              parameters: userRegisterBody.toJSON(),
                                              requestEncoding: requestEncoding,
                                              requestHeaders: requestHeaders)

    return apiRequest(with: parameters, additionalValidStatusCodes: additionalValidStatusCodes, decoder: JSONDecoder())
}
```