### PR TITLE
Format response type in Swift

### DIFF
--- a/Swift/blocks/method/method-declaration.twig
+++ b/Swift/blocks/method/method-declaration.twig
@@ -9,4 +9,4 @@
 
 {%- set funcName = utils.decapitalize(method.name) -%}
 
-{{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ " " }}{%- endif -%}requestEncoding: ParameterEncoding?, requestHeaders: HTTPHeaders?, additionalValidStatusCodes: Set<Int>) -> Single<{{ method.responseType.type.typeName }}>
+{{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ " " }}{%- endif -%}requestEncoding: ParameterEncoding?, requestHeaders: HTTPHeaders?, additionalValidStatusCodes: Set<Int>) -> Single<{{ utils.formatValueType(method.apiResponseType) }}>

--- a/Swift/blocks/method/method-func.twig
+++ b/Swift/blocks/method/method-func.twig
@@ -14,7 +14,7 @@
     public {{ isStatic ? "static " : "" }}func {{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyTypeName }},{{ "\n                   " }}{%- endif -%}
                    requestEncoding: ParameterEncoding? = nil,
                    requestHeaders: HTTPHeaders? = nil,
-                   additionalValidStatusCodes: Set<Int> = []) -> Single<{{ method.responseType.type.typeName }}> {
+                   additionalValidStatusCodes: Set<Int> = []) -> Single<{{ utils.formatValueType(method.apiResponseType) }}> {
 
         {% if isStatic -%}
           return shared.{{ funcName }}({%- if hasBody -%}{{ bodyParamName }}: {{ bodyParamName }},{{ "\n                   " }}{%- endif -%}


### PR DESCRIPTION
Now not only the class name could be the response type, but also array type. 
So `-> Single<A[]>` should be formated as `-> Single<[A]>`