### PR TITLE
Replace .typeName with .canonicalName

### DIFF
--- a/KotlinOutputFiles/DateFactory.kt
+++ b/KotlinOutputFiles/DateFactory.kt
@@ -7,9 +7,14 @@ import java.lang.reflect.Type
 class DateFactory : JsonAdapter.Factory {
 
     override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
-        return when (type.typeName) {
-            DateTime::class.java.typeName -> DateTimeJsonAdapter(getPatterns(annotations))
-            LocalDate::class.java.typeName -> LocalDateJsonAdapter(getPatterns(annotations))
+        val typeName = when(type) {
+            is Class<*> -> type.canonicalName
+            else -> type.toString()
+        }
+
+        return when (typeName) {
+            DateTime::class.java.canonicalName -> DateTimeJsonAdapter(getPatterns(annotations))
+            LocalDate::class.java.canonicalName -> LocalDateJsonAdapter(getPatterns(annotations))
             else -> null
         }
     }

--- a/KotlinOutputFiles/DateFactory.kt
+++ b/KotlinOutputFiles/DateFactory.kt
@@ -6,7 +6,7 @@ import java.lang.reflect.Type
 
 class DateFactory : JsonAdapter.Factory {
 
-    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+    override fun create(type: Type, annotations: Set<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
         val typeName = when(type) {
             is Class<*> -> type.canonicalName
             else -> type.toString()
@@ -19,7 +19,7 @@ class DateFactory : JsonAdapter.Factory {
         }
     }
 
-    private fun getPatterns(annotations: MutableSet<out Annotation>) = annotations
+    private fun getPatterns(annotations: Set<out Annotation>) = annotations
             .map { it as? Format }
             .firstOrNull()
             ?.patterns


### PR DESCRIPTION
Method .typeName available since 26 api level, when 21+ api is used